### PR TITLE
NeedsQA label and automerge toggling updates

### DIFF
--- a/_github/workflows/dependabot-prs.yml
+++ b/_github/workflows/dependabot-prs.yml
@@ -4,12 +4,27 @@ on:
     types: [opened, synchronize, reopened, labeled]
 jobs:
   build:
+    if: startsWith(github.head_ref, 'dependabot/')
     runs-on: ubuntu-latest
     steps:
+      - name: Get unique committers
+        id: unique-committers
+        run: echo "::set-output name=committers::$(gh pr view $PR_URL --json commits --jq '[.commits.[] | .authors.[] | .login] | unique')"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.PANORAMA_BOT_RW_TOKEN}}
       # The last step enables auto-merge in certain situations, but we don't want dependabots that require
       # additional work to accidentally get merged before code review so we turn it off here.
-      - name: Disable auto-merge after any change
+      - name: Disable auto-merge if there are commits from someone other than Dependabot
+        if: steps.unique-committers.outputs.committers != '["dependabot[bot]"]'
         run: gh pr merge --disable-auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.PANORAMA_BOT_RW_TOKEN}}
+      - name: Add the Needs QA label to dependabots after any change by someone other than the dependabot bot
+        # Need to avoid the situation where someone removes the "Needs QA" label and we are adding it back.
+        if: ${{ github.actor != 'dependabot[bot]' && github.event.action != 'labeled' }}
+        run: gh pr edit "$PR_URL" --add-label "Needs QA"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.PANORAMA_BOT_RW_TOKEN}}


### PR DESCRIPTION
This copies over the `dependabot-prs` file that Jake and I have been working on in the forklift repo. 
This adds:
- adding back the needs qa label whenever someone who isn't dependabot does something that isn't changing a label
- disabling automerge when someone other than dependabot has committed to the branch