### PR TITLE
Update README.md for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,23 +6,24 @@ repo, largely without modification.
 
 ## Adding automation to a project
 
-Let's say we have a repo, `my-new-project` and we want to set up Dependabot in
-it. First, you must follow **_all_** the other instructions
+### Step 1
+Follow **_all_** the other instructions
 [in Panopedia](https://panoramaed.atlassian.net/wiki/spaces/ENG/pages/2162262038/Setting+up+a+new+GitHub+repository).
 
-Then we add the configuration and automation files, which can be accomplished in
+### Step 2
+Add the configuration and automation files, which can be accomplished in
 one of the following two ways:
 
-### Option A: Using install.sh
-
+**Option A: Using install.sh**
+    
 ```shell
 cd my-new-project
 curl -s https://raw.githubusercontent.com/panorama-ed/base-dependabot-automation/main/install.sh | bash -
 ```
 
-### Option B: Manually copying files
+**Option B: Manually copying files**
 
-1. Create `.github/workflows`
+Create `.github/workflows`
 
 ```shell
 cd my-new-project
@@ -30,16 +31,18 @@ mkdir -p .github/workflows
 curl -o .github/workflows/dependabot-prs.yml https://raw.githubusercontent.com/panorama-ed/base-dependabot-automation/main/_github/workflows/dependabot-prs.yml
 ```
 
-2. Create `.github/dependabot.yml`
+Then create `.github/dependabot.yml`
 
 ```shell
 cd my-new-project
 curl -o .github/dependabot.yml https://raw.githubusercontent.com/panorama-ed/base-dependabot-automation/main/_github/dependabot.yml
 ```
 
-3. Tweak `dependabot.yml` for your project
+### Step 3
+Tweak `dependabot.yml` for your project
     - Instructions and documentation are
 in [Panopedia](https://panoramaed.atlassian.net/wiki/spaces/ENG/pages/2162262038/Setting+up+a+new+GitHub+repository#Configure-Dependabot)
 and [GitHub](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates)
 
-4. Commit files to repository
+### Step 4
+Commit files to repository


### PR DESCRIPTION
Previous numbering in README.md made it appear as if steps 3 and 4 were only necessary if following Option B of manually copying files. Step numbering is corrected in this PR.